### PR TITLE
Fix okex order api changing

### DIFF
--- a/vnpy/trader/gateway/okexGateway/future.py
+++ b/vnpy/trader/gateway/okexGateway/future.py
@@ -222,7 +222,7 @@ class OkexfRestApi(RestClient):
             # 6 = 未成交, 部分成交
             req = {
                 'instrument_id': symbol,
-                'status': 6
+                'state': 6
             }
             path = f'/api/futures/v3/orders/{symbol}'
             self.addRequest('GET', path, params=req,
@@ -258,7 +258,7 @@ class OkexfRestApi(RestClient):
         # 未完成(包含未成交和部分成交)
         req = {
             'instrument_id': symbol,
-            'status': 6
+            'state': 6
         }
         path = f'/api/futures/v3/orders/{symbol}'
         request = Request('GET', path, params=req, callback=None, data=None, headers=None)
@@ -279,7 +279,7 @@ class OkexfRestApi(RestClient):
 
     def onCancelAll(self, data, request):
         orderids = [str(order['order_id']) for order in data if
-                    order['status'] == '0' or order['status'] == '1']
+                    str(order['state']) in ['0','1','3']]
         if request.extra:
             orderids = list(set(orderids).intersection(set(request.extra.split(","))))
         for i in range(len(orderids) // 10 + 1):

--- a/vnpy/trader/gateway/okexGateway/spot.py
+++ b/vnpy/trader/gateway/okexGateway/spot.py
@@ -284,7 +284,7 @@ class OkexSpotRestApi(RestClient):
 
     def onCancelAll(self, data, request):
         orderids = [str(order['order_id']) for order in data if
-                   order['status'] == 'open' or order['status'] == 'part_filled']
+                   str(order['state']) in ['0','1','3']]
         if request.extra:
             orderids = list(set(orderids).intersection(set(request.extra.split(","))))
         for i in range(len(orderids) // 10 + 1):

--- a/vnpy/trader/gateway/okexGateway/swap.py
+++ b/vnpy/trader/gateway/okexGateway/swap.py
@@ -219,7 +219,7 @@ class OkexSwapRestApi(RestClient):
             # 6 = 未成交, 部分成交
             req = {
                 'instrument_id': symbol,
-                'status': 6
+                'state': 6
             }
             path = f'/api/swap/v3/orders/{symbol}'
             self.addRequest('GET', path, params=req,
@@ -252,7 +252,7 @@ class OkexSwapRestApi(RestClient):
         vtOrderIDs = []
         # 未完成(包含未成交和部分成交)
         req = {
-            'status': 6
+            'state': 6
         }
         path = f'/api/swap/v3/orders/{symbol}'
         request = Request('GET', path, params=req, callback=None, data=None, headers=None)
@@ -273,7 +273,7 @@ class OkexSwapRestApi(RestClient):
 
     def onCancelAll(self, data, request):
         orderids = [str(order['order_id']) for order in data if
-                    order['status'] == '0' or order['status'] == '1']
+                    str(order['state']) in ['0','1','3']]
         if request.extra:
             orderids = list(set(orderids).intersection(set(request.extra.split(","))))
         for i in range(len(orderids) // 10 + 1):


### PR DESCRIPTION
1.okex今天改了order的接口。状态字段为state，增加状态 '3': 已提交，未来将去掉status字段。
2.增加了websocket登录成功的日志输出，用的WARNING级别，为了断线重连后dingding可以收到update。
3.将轮询打印的语句改为DEBUG级别。
4.restful 请求失败时，error语句增加请求的接口地址